### PR TITLE
fix security

### DIFF
--- a/pages/api/icon/birth.ts
+++ b/pages/api/icon/birth.ts
@@ -6,8 +6,8 @@ export default function handler(
 ) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Content-Type', 'image/svg+xml');
-  let { fill = 'fff' } = req.query;
-  if (fill instanceof String) fill = fill.substring(0, 6);
+  const rawFill = req.query.fill;
+  const fill = (typeof rawFill === 'string' ? rawFill : 'fff').replace(/[^a-fA-F0-9]/g, '').substring(0, 6) || 'fff';
   res.status(200).send(`<?xml version="1.0" encoding="utf-8"?>
   <svg width="25px" height="25px" viewBox="0 0 25 25" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
     <g id="Group-4">

--- a/pages/api/icon/chat.ts
+++ b/pages/api/icon/chat.ts
@@ -6,8 +6,8 @@ export default function handler(
 ) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Content-Type', 'image/svg+xml');
-  let { fill = 'fff' } = req.query;
-  if (fill instanceof String) fill = fill.substring(0, 6);
+  const rawFill = req.query.fill;
+  const fill = (typeof rawFill === 'string' ? rawFill : 'fff').replace(/[^a-fA-F0-9]/g, '').substring(0, 6) || 'fff';
   res.status(200).send(`<?xml version="1.0" encoding="utf-8"?>
     <svg width="39px" height="31px" viewBox="0 0 39 31" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
       <g id="Group-2">

--- a/pages/api/icon/close.ts
+++ b/pages/api/icon/close.ts
@@ -6,8 +6,8 @@ export default function handler(
 ) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Content-Type', 'image/svg+xml');
-  let { fill = 'fff' } = req.query;
-  if (fill instanceof String) fill = fill.substring(0, 6);
+  const rawFill = req.query.fill;
+  const fill = (typeof rawFill === 'string' ? rawFill : 'fff').replace(/[^a-fA-F0-9]/g, '').substring(0, 6) || 'fff';
   res.status(200).send(`<?xml version="1.0" encoding="utf-8"?>
   <svg width="7px" height="7px" viewBox="0 0 7 7" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
     <g id="Group">

--- a/pages/api/icon/download.ts
+++ b/pages/api/icon/download.ts
@@ -6,8 +6,8 @@ export default function handler(
 ) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Content-Type', 'image/svg+xml');
-  let { fill = 'fff' } = req.query;
-  if (fill instanceof String) fill = fill.substring(0, 6);
+  const rawFill = req.query.fill;
+  const fill = (typeof rawFill === 'string' ? rawFill : 'fff').replace(/[^a-fA-F0-9]/g, '').substring(0, 6) || 'fff';
   res.status(200).send(`<?xml version="1.0" encoding="utf-8"?>
   <svg width="90px" height="90px" viewBox="0 0 90 90" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
     <g id="download">

--- a/pages/api/icon/index.ts
+++ b/pages/api/icon/index.ts
@@ -6,8 +6,8 @@ export default function handler(
 ) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Content-Type', 'image/svg+xml');
-  let { fill = 'fff' } = req.query;
-  if (fill instanceof String) fill = fill.substring(0, 6);
+  const rawFill = req.query.fill;
+  const fill = (typeof rawFill === 'string' ? rawFill : 'fff').replace(/[^a-fA-F0-9]/g, '').substring(0, 6) || 'fff';
   res.status(200).send(`<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" x="0" y="0" viewBox="0 0 512 477.9" fill="#${fill}">
 <path d="M101.8 396.4c-53.3 0-98.4 53.8-101.8 79.5 81.4 7.9 196.1-6.8 252.1-65-74.7 13.5-135.9-5.2-150.3-14.5zM281.4 412.5c55.1 73.3 137.7 58.5 230.5 63.3 3.5-42.1-73.2-80.9-103.9-82.2-39.9 28.5-123.3 19.5-126.6 18.9z"></path>
 <path d="M256.4 0C136.8 45 31.5 151.4 31.5 259.4c0 85 68.4 153.9 195.3 137.3 3.9-.5 7.6-1.1 11.2-1.7-1.1-.4-2.1-.9-2.9-1.3-19.4-9.8-53.4-56.7-39-112.6 1.4 59.3 39.7 102.6 57.1 111 2.7 1.3 11.9 4.6 25.5 6.7 51.9 8 164.9 4.7 187.9-116.7C498.9 111.4 256.4 0 256.4 0z"></path>

--- a/pages/api/icon/info.ts
+++ b/pages/api/icon/info.ts
@@ -6,8 +6,8 @@ export default function handler(
 ) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Content-Type', 'image/svg+xml');
-  let { fill = 'fff' } = req.query;
-  if (fill instanceof String) fill = fill.substring(0, 6);
+  const rawFill = req.query.fill;
+  const fill = (typeof rawFill === 'string' ? rawFill : 'fff').replace(/[^a-fA-F0-9]/g, '').substring(0, 6) || 'fff';
   res.status(200).send(`<?xml version="1.0" encoding="utf-8"?>
     <svg width="34.053787px" height="39.500008px" viewBox="0 0 34.053787 39.500008" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
       <defs>

--- a/pages/api/icon/line.ts
+++ b/pages/api/icon/line.ts
@@ -6,8 +6,8 @@ export default function handler(
 ) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Content-Type', 'image/svg+xml');
-  let { fill = 'fff' } = req.query;
-  if (fill instanceof String) fill = fill.substring(0, 6);
+  const rawFill = req.query.fill;
+  const fill = (typeof rawFill === 'string' ? rawFill : 'fff').replace(/[^a-fA-F0-9]/g, '').substring(0, 6) || 'fff';
   res.status(200).send(`<?xml version="1.0" encoding="utf-8"?>
     <svg width="3px" height="9.5px" viewBox="0 0 3 9.5" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
       <path d="M1.5 0.5L1.5 9" id="Line" fill="none" fill-rule="evenodd" stroke="#${fill}" stroke-width="1" stroke-linecap="square" />

--- a/pages/api/icon/pngload.ts
+++ b/pages/api/icon/pngload.ts
@@ -6,8 +6,8 @@ export default function handler(
 ) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Content-Type', 'image/svg+xml');
-  let { fill = 'fff' } = req.query;
-  if (fill instanceof String) fill = fill.substring(0, 6);
+  const rawFill = req.query.fill;
+  const fill = (typeof rawFill === 'string' ? rawFill : 'fff').replace(/[^a-fA-F0-9]/g, '').substring(0, 6) || 'fff';
   res.status(200).send(`<?xml version="1.0" encoding="utf-8"?>
   <svg width="48px" height="48px" viewBox="0 0 48 48" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
     <defs>

--- a/pages/api/icon/setting.ts
+++ b/pages/api/icon/setting.ts
@@ -6,8 +6,8 @@ export default function handler(
 ) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Content-Type', 'image/svg+xml');
-  let { fill = 'fff' } = req.query;
-  if (fill instanceof String) fill = fill.substring(0, 6);
+  const rawFill = req.query.fill;
+  const fill = (typeof rawFill === 'string' ? rawFill : 'fff').replace(/[^a-fA-F0-9]/g, '').substring(0, 6) || 'fff';
   res.status(200).send(`<?xml version="1.0" encoding="utf-8"?>
   <svg width="48px" height="48px" viewBox="0 0 48 48" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
     <defs>

--- a/pages/api/icon/svgload.ts
+++ b/pages/api/icon/svgload.ts
@@ -6,8 +6,8 @@ export default function handler(
 ) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Content-Type', 'image/svg+xml');
-  let { fill = 'fff' } = req.query;
-  if (fill instanceof String) fill = fill.substring(0, 6);
+  const rawFill = req.query.fill;
+  const fill = (typeof rawFill === 'string' ? rawFill : 'fff').replace(/[^a-fA-F0-9]/g, '').substring(0, 6) || 'fff';
   res.status(200).send(`<?xml version="1.0" encoding="utf-8"?>
   <svg width="48px" height="48px" viewBox="0 0 48 48" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
     <defs>

--- a/pages/api/icon/upload.ts
+++ b/pages/api/icon/upload.ts
@@ -6,8 +6,8 @@ export default function handler(
 ) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Content-Type', 'image/svg+xml');
-  let { fill = 'fff' } = req.query;
-  if (fill instanceof String) fill = fill.substring(0, 6);
+  const rawFill = req.query.fill;
+  const fill = (typeof rawFill === 'string' ? rawFill : 'fff').replace(/[^a-fA-F0-9]/g, '').substring(0, 6) || 'fff';
   res.status(200).send(`<?xml version="1.0" encoding="utf-8"?>
   <svg width="90px" height="90px" viewBox="0 0 90 90" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
     <g id="upload">

--- a/pages/api/msg.ts
+++ b/pages/api/msg.ts
@@ -3,14 +3,31 @@ import MinusCode from 'minus-code';
 
 const mccode = new MinusCode();
 
+function sanitizeHtml(input: string): string {
+    return input
+        .replace(/<script[\s\S]*?<\/script>/gi, '')
+        .replace(/\son\w+\s*=\s*["'][^"']*["']/gi, '')
+        .replace(/\son\w+\s*=\s*[^\s>]*/gi, '')
+        .replace(/javascript\s*:/gi, '')
+        .replace(/vbscript\s*:/gi, '');
+}
+
 export default async function handler(
     req: NextApiRequest,
     res: NextApiResponse<string>
 ) {
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.setHeader('Content-Type', 'image/svg+xml');
-    let { w, h } = req.query;
-    let { data } = req.body;
+
+    const rawW = req.query.w;
+    const rawH = req.query.h;
+    const w = Math.max(1, Math.min(10000, parseInt(typeof rawW === 'string' ? rawW : '500', 10) || 500));
+    const h = Math.max(1, Math.min(10000, parseInt(typeof rawH === 'string' ? rawH : '500', 10) || 500));
+
+    const { data } = req.body;
+    const decoded = typeof data === 'string' ? mccode.decode(data) : '';
+    const safeData = sanitizeHtml(typeof decoded === 'string' ? decoded : '');
+
     const svg = `
 <svg viewBox="0 0 ${w} ${h}" xmlns="http://www.w3.org/2000/svg">
 <style>
@@ -31,7 +48,7 @@ div.sensei > div#img > img {width: auto;height: 200px;float: right;margin: 5px 1
 
 <foreignObject x="0" y="0" width="${w}" height="${h}">
 <div xmlns="http://www.w3.org/1999/xhtml">
-${mccode.decode(data)}
+${safeData}
 </div>
 </foreignObject>
 </svg>


### PR DESCRIPTION
## summary
fixes multiple xss vulnerabilities found in the icon and msg api endpoints.

## changes
- `pages/api/icon/*.ts` — replace broken `instanceof string` check with `typeof` and whitelist hex characters for `fill` parameter
- `pages/api/msg.ts` — validate and clamp `w`/`h` to integer range, strip dangerous html (script tags, event handlers, javascript:/vbscript: uris) from decoded `data` payload

## vulnerabilities fixed
- **svg attribute injection** via `fill` query param on all icon endpoints
- **html injection** via `data` body param on msg endpoint (`<foreignobject>` bypass)
- **dimension injection** via `w`/`h` query params on msg endpoint

## testing
- verified `fill` injection payload is blocked and stripped to hex-only
- verified `onerror` and other event handlers are stripped from decoded html
- verified `w`/`h` are parsed as integers and clamped to safe range

## image testing
- test `fill` injection
<img width="1440" height="830" alt="Untitled27_20260314172528" src="https://github.com/user-attachments/assets/90165009-07ce-400f-b90c-dde4a828645a" />

- test `msg.ts` inject via `w`/`h`
<img width="1423" height="739" alt="Untitled25_20260314164328" src="https://github.com/user-attachments/assets/d575baf6-57d0-4d2d-a9e9-f94ef4ab5817" />

- test `msg.ts` — Inject via `data`
note: `data` must be encoded using `minus-code` first
<img width="1422" height="740" alt="Untitled26_20260314164447" src="https://github.com/user-attachments/assets/a83466b6-1362-4d46-a02d-d4f67e7d5258" />
